### PR TITLE
Publish docker image using gh actions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -11,19 +11,20 @@ jobs:
     runs-on: ubuntu-latest
     environment: docker
     env:
-      tag_minor: "1.0"
+      tag_minor: "${{ github.repository }}:1.0"
+      tag_patch: "${{ github.repository }}:1.0.${{ github.run_number }}"
     steps:
     - uses: actions/checkout@v2
     - name: Build the Docker image
       run: |
-        docker pull voiski/pytago:${tag_minor} || true
-        docker build . --cache-from voiski/pytago:${tag_minor} --tag voiski/pytago:${tag_minor}.${GITHUB_RUN_ID}
+        docker pull ${tag_minor} || true
+        docker build . --cache-from ${tag_minor} --tag ${tag_patch}
     - name: Login to Docker Hub
       uses: docker/login-action@v1
       with:
-        username: voiski
-        password: ${{ secrets.VOISKI_DOCKER_HUB }}
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Publish Docker image
       run: |
-        docker tag voiski/pytago:${tag_minor}.${GITHUB_RUN_ID} voiski/pytago:${tag_minor}
-        docker push voiski/pytago:${tag_minor}
+        docker tag ${tag_patch} ${tag_minor}
+        docker push ${{ github.repository }} --all-tags

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,29 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    environment: docker
+    env:
+      tag_minor: "1.0"
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build the Docker image
+      run: |
+        docker pull voiski/pytago:${tag_minor} || true
+        docker build . --cache-from voiski/pytago:${tag_minor} --tag voiski/pytago:${tag_minor}.${GITHUB_RUN_ID}
+    - name: Login to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: voiski
+        password: ${{ secrets.VOISKI_DOCKER_HUB }}
+    - name: Publish Docker image
+      run: |
+        docker tag voiski/pytago:${tag_minor}.${GITHUB_RUN_ID} voiski/pytago:${tag_minor}
+        docker push voiski/pytago:${tag_minor}


### PR DESCRIPTION
It is a suggestion to build and publish the docker image to dockerhub using github actions.

The setup needed is:
1.  Access your Dockerhub account in [Security configs][token] and generate an access token. 
    1. Also, create [the dockerhub repository][repo] for pytago
2. Access its GH repo settings and [create a new environment][env] with name `docker`.
    1. Add in this new environment the docker user and its access token as `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` (I made it this way so I could run it in my fork as you can run in your repo)
4. Now merge this PR and be happy.

> Some details here. The action script assumes your docker user is the same as the GH user. I feel a little dumb now about step **2.i** since I could simply replace the `DOCKERHUB_USERNAME` with `${{ github.repository_owner }}`. But I also wonder if you may have another docker user that differs from the GH user, so we can maybe change the docker namespace to reuse the `DOCKERHUB_USERNAME`. I'm good to make any of those changes if it makes sense to you.

[token]: https://hub.docker.com/settings/security
[env]: https://github.com/voiski/pytago/settings/environments
[repo]: https://hub.docker.com/repositories