### PR TITLE
Add support for bitwise NOT operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -5139,6 +5139,34 @@ func main() {
 ```
 </td></tr></table>
 
+### bitwisenot
+
+<table><tr><th>Python</th><th>Go</th></tr><tr><td>
+
+```python
+def main():
+	yeah = 9
+	yeah &= ~0x3
+	print(yeah)
+
+if __name__ == '__main__':
+    main()
+```
+</td><td>
+
+```go
+package main
+
+import "fmt"
+
+func main() {
+	yeah := 9
+	yeah &= ^3
+	fmt.Println(yeah)
+}
+```
+</td></tr></table>
+
 ### index
 
 <table><tr><th>Python</th><th>Go</th></tr><tr><td>

--- a/examples/bitwisenot.go
+++ b/examples/bitwisenot.go
@@ -1,0 +1,9 @@
+package main
+
+import "fmt"
+
+func main() {
+	yeah := 9
+	yeah &= ^3
+	fmt.Println(yeah)
+}

--- a/examples/bitwisenot.py
+++ b/examples/bitwisenot.py
@@ -1,0 +1,7 @@
+def main():
+	yeah = 9
+	yeah &= ~0x3
+	print(yeah)
+
+if __name__ == '__main__':
+    main()

--- a/pytago/go_ast/core.py
+++ b/pytago/go_ast/core.py
@@ -593,8 +593,6 @@ class Expr(GoAST):
     def __neg__(self) -> 'UnaryExpr':
         return UnaryExpr(Op=token.SUB, X=self)
 
-    def __invert__(self) -> 'UnaryExpr':
-        return UnaryExpr(Op=token.XOR, X=self)
 
     def or_(self, Y: 'Expr') -> 'BinaryExpr':
         """

--- a/pytago/go_ast/core.py
+++ b/pytago/go_ast/core.py
@@ -593,6 +593,9 @@ class Expr(GoAST):
     def __neg__(self) -> 'UnaryExpr':
         return UnaryExpr(Op=token.SUB, X=self)
 
+    def __invert__(self) -> 'UnaryExpr':
+        return UnaryExpr(Op=token.XOR, X=self)
+
     def or_(self, Y: 'Expr') -> 'BinaryExpr':
         """
         Shorthand way to describe the binary expression self || Y
@@ -3705,6 +3708,7 @@ class UnaryExpr(Expr):
             case ast.USub(): op = token.SUB
             case ast.UAdd(): op = ast.UAdd
             case ast.Not(): op = token.NOT
+            case ast.Invert(): op = token.XOR
             case _: raise NotImplementedError((node, node.op))
         X = build_expr_list([node.operand])[0]
         return cls(Op=op, X=X, **kwargs)

--- a/pytago/tests/test_core.py
+++ b/pytago/tests/test_core.py
@@ -248,6 +248,9 @@ class Test(TestCase):
     def test_algointersection(self):
         self.assert_examples_match("algointersection")
 
+    def test_bitwisenot(self):
+        self.assert_examples_match("bitwisenot")
+
     # In development
 
     #

--- a/scripts/generate_readme.py
+++ b/scripts/generate_readme.py
@@ -46,6 +46,7 @@ def main():
         example_name = split(example)[-1].removesuffix(".py").removesuffix(".go")
         if example_name in DISABLED_EXAMPLES:
             continue
+        print(example_name)
         is_python = i % 2 == 0
         if is_python:
             assert example.endswith(".py")


### PR DESCRIPTION
Python has `~0x3`, which upon research and testing shows that this is basically the same result as Golang's "^0x3". 
This adds support for that.